### PR TITLE
fix(RouterSource): Initialize this._history$ with _runSA.remember

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyclic-router",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A router driver built for Cycle.js",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -26,7 +26,7 @@
     "@cycle/base": "^4.0.0",
     "@cycle/rx-adapter": "^3.0.0",
     "@cycle/rxjs-adapter": "^3.0.0",
-    "@cycle/xstream-adapter": "^3.0.1",
+    "@cycle/xstream-adapter": "^3.0.2 ",
     "assert": "^1.4.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
@@ -44,7 +44,7 @@
     "typings": "^0.8.1",
     "uglify-js": "^2.6.2",
     "validate-commit-message": "^3.0.1",
-    "xstream": "^5.0.5"
+    "xstream": "^5.0.6"
   },
   "config": {
     "ghooks": {


### PR DESCRIPTION
I encountered an issue where the the defined route stream was not emitting even though I could listen to the history$ and the route should have matched.  I fixed it by making a common `remember` call on the StreamAdapter.  I haven't tracked down why this fixed my issue, but I created this PR not necessarily to get it merged but to at a minimum have a discussion about the root cause.