### PR TITLE
Explain how to dynamically change route in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,38 @@ const routes = {
   '/:id': id => sources => YourComponent({props$: Observable.of({id}), ...sources})
 }
 ```
+
+### Dynamically change route
+
+You can dynamically change route from code by emitting inputs handled by [the history driver](http://cycle.js.org/history/docs/#historyDriver).
+
+```js
+function main(sources) {
+  // ...
+  const homePageClick$ = sources.DOM.select(".home").events("click");
+  const previousPageClick$ = sources.DOM.select(".previous").events("click");
+  const nextPageClick$ = sources.DOM.select(".next").events("click");
+  const oldPageClick$ = sources.DOM.select(".old").events("click");
+  const aboutPageClick$ = sources.DOM.select(".about").events("click");
+  
+  return {
+    // ...
+    router: xs.merge(
+        // Go to page "/"
+        homePageClick$.mapTo("/"),
+        
+        // Go back to previous page
+        previousPageClick$.mapTo({ type: "goBack" }),
+        
+        // Go forward to next page
+        nextPageClick$.mapTo({ type: "goForward" }),
+        
+        // Go back from 5 pages
+        oldPageClick$.mapTo({ type: "go", value: -5 }),
+        
+        // Go to page "/about" with some state set to router's location
+        aboutPageClick$.mapTo({ pathname: "/about", state: { some: "state" } })
+    ),
+  };
+}
+```


### PR DESCRIPTION
I've had some hard time figuring out how I could dynamically go back to previous page in my app. 

Actually, I found myself re-implementing a lot of stuff before the AH-AH moment when I realized that I could pass inputs [the cyclejs/history's driver](http://cycle.js.org/history/docs/#historyDriver) would accept… and so that `click$.mapTo({ type: "goBack" })` was the droid I was looking for 👋 

I thought that putting it explicitly in the README could help people connecting dots faster than I did 😄 

What do you think? Does that look clear or should I improve something?