### PR TITLE
feat(makeRouterDriver): Require injection of route matching algorithm

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,8 +1,16 @@
-export interface RouteDefinitions {
+export interface RouteDefinitionsMap {
   [sourcePath: string]: any;
 }
 
-export interface SwitchPathReturn {
+export interface RouteDefinitionsArray {
+  [sourceIndex: number]: any;
+}
+
+export interface RouteMatcherReturn {
   path: string;
   value: any;
 }
+
+export interface RouteMatcher {
+  (path: string, routes: RouteDefinitionsMap | RouteDefinitionsArray): RouteMatcherReturn;
+} 

--- a/src/makeRouterDriver.ts
+++ b/src/makeRouterDriver.ts
@@ -1,7 +1,7 @@
 import {StreamAdapter} from '@cycle/base';
 import {makeHistoryDriver} from '@cycle/history';
 import {History, HistoryDriverOptions} from '@cycle/history/lib/interfaces';
-
+import {RouteMatcher} from './interfaces';
 import {RouterSource} from './RouterSource';
 
 /**
@@ -11,7 +11,7 @@ import {RouterSource} from './RouterSource';
  * @method makeRouterDriver
  * @return {routerDriver} The router driver function
  */
-function makeRouterDriver(history: History, options?: HistoryDriverOptions) {
+function makeRouterDriver(history: History, routeMatcher: RouteMatcher, options?: HistoryDriverOptions) {
   const historyDriver = makeHistoryDriver(history, options);
   /**
    * The actual router driver.
@@ -25,7 +25,7 @@ function makeRouterDriver(history: History, options?: HistoryDriverOptions) {
    */
   return function routerDriver(sink$: any, runSA: StreamAdapter) {
     const history$ = runSA.remember(historyDriver(sink$, runSA));
-    return new RouterSource(history$, [], history.createHref, runSA);
+    return new RouterSource(history$, [], history.createHref, runSA, routeMatcher);
   };
 }
 

--- a/test/rx.js
+++ b/test/rx.js
@@ -4,6 +4,7 @@ import assert from 'assert'
 import RxAdapter from '@cycle/rx-adapter'
 import {Observable} from 'rx'
 import {makeRouterDriver, createServerHistory} from '../lib'
+import switchPath from 'switch-path';
 
 describe('Cyclic Router - Rx 4', () => {
   describe('makeRouterDriver', () => {
@@ -19,7 +20,7 @@ describe('Cyclic Router - Rx 4', () => {
         '`createHref` and `dispose`',
         () => {
           const history = createServerHistory('/')
-          const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+          const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           assert.notStrictEqual(router.path, null)
           assert.strictEqual(typeof router.path, 'function')
           assert.notStrictEqual(router.define, null)
@@ -38,7 +39,7 @@ describe('Cyclic Router - Rx 4', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory('/')
-        const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+        const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           .path('/')
         assert.notStrictEqual(router.path, null)
         assert.strictEqual(typeof router.path, 'function')
@@ -57,7 +58,7 @@ describe('Cyclic Router - Rx 4', () => {
         '/path/that/is/correct',
       ]
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.from(routes), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.from(routes), RxAdapter)
         .path('/path')
 
       router.history$.subscribe((location) => {
@@ -74,7 +75,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.from(routes), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.from(routes), RxAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -92,7 +93,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.from(routes), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.from(routes), RxAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -111,7 +112,7 @@ describe('Cyclic Router - Rx 4', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory('/')
-        const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+        const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           .define({})
         assert.strictEqual(router instanceof Observable, true)
         assert.strictEqual(typeof router.subscribe, 'function')
@@ -127,7 +128,7 @@ describe('Cyclic Router - Rx 4', () => {
       }
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.define(defintion)
 
       match$.skip(1).subscribe(({path, value, location}) => {
@@ -153,7 +154,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.path('/some').path('/nested').define(defintion)
 
       match$.subscribe(({path, value, location}) => {
@@ -181,7 +182,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.path('/some').path('/nested').define(definition)
 
       match$.subscribe(({path, value, location}) => {
@@ -208,7 +209,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router
           .path('/some').path('/nested').define(defintion)
 
@@ -235,7 +236,7 @@ describe('Cyclic Router - Rx 4', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router
           .path('/some').path('/nested').define(defintion)
 

--- a/test/rxjs.js
+++ b/test/rxjs.js
@@ -4,6 +4,7 @@ import assert from 'assert'
 import RxAdapter from '@cycle/rxjs-adapter'
 import {Observable} from 'rxjs'
 import {makeRouterDriver, createServerHistory} from '../lib'
+import switchPath from 'switch-path';
 
 describe('Cyclic Router - Rx 5', () => {
   describe('makeRouterDriver', () => {
@@ -19,7 +20,7 @@ describe('Cyclic Router - Rx 5', () => {
         '`createHref` and `dispose`',
         () => {
           const history = createServerHistory('/')
-          const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+          const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           assert.notStrictEqual(router.path, null)
           assert.strictEqual(typeof router.path, 'function')
           assert.notStrictEqual(router.define, null)
@@ -38,7 +39,7 @@ describe('Cyclic Router - Rx 5', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory('/')
-        const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+        const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           .path('/')
         assert.notStrictEqual(router.path, null)
         assert.strictEqual(typeof router.path, 'function')
@@ -57,7 +58,7 @@ describe('Cyclic Router - Rx 5', () => {
         '/path/that/is/correct',
       ]
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
         .path('/path')
 
       router.history$.subscribe((location) => {
@@ -76,7 +77,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -96,7 +97,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -117,7 +118,7 @@ describe('Cyclic Router - Rx 5', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory('/')
-        const router = makeRouterDriver(history)(Observable.of('/'), RxAdapter)
+        const router = makeRouterDriver(history, switchPath)(Observable.of('/'), RxAdapter)
           .define({})
         assert.strictEqual(router instanceof Observable, true)
         assert.strictEqual(typeof router.subscribe, 'function')
@@ -137,7 +138,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.define(defintion)
 
       match$.skip(1).subscribe(({path, value, location}) => {
@@ -162,7 +163,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.path('/some').path('/nested').define(defintion)
 
       match$.subscribe(({path, value, location}) => {
@@ -190,7 +191,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router.path('/some').path('/nested').define(definition)
 
       match$.subscribe(({path, value, location}) => {
@@ -217,7 +218,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router
           .path('/some').path('/nested').define(defintion)
 
@@ -244,7 +245,7 @@ describe('Cyclic Router - Rx 5', () => {
       ]
 
       const history = createServerHistory('/')
-      const router = makeRouterDriver(history)(Observable.never(), RxAdapter)
+      const router = makeRouterDriver(history, switchPath)(Observable.never(), RxAdapter)
       const match$ = router
           .path('/some').path('/nested').define(defintion)
 

--- a/test/xstream.js
+++ b/test/xstream.js
@@ -4,6 +4,7 @@ import assert from 'assert'
 import XSAdapter from '@cycle/xstream-adapter'
 import xs from 'xstream'
 import {makeRouterDriver, createServerHistory} from '../lib'
+import switchPath from 'switch-path';
 
 describe('Cyclic Router - XStream', () => {
   describe('makeRouterDriver', () => {
@@ -19,7 +20,7 @@ describe('Cyclic Router - XStream', () => {
         '`createHref` and `dispose`',
         () => {
           const history = createServerHistory()
-          const router = makeRouterDriver(history)(xs.of('/'), XSAdapter)
+          const router = makeRouterDriver(history, switchPath)(xs.of('/'), XSAdapter)
           assert.notStrictEqual(router.path, null)
           assert.strictEqual(typeof router.path, 'function')
           assert.notStrictEqual(router.define, null)
@@ -38,7 +39,7 @@ describe('Cyclic Router - XStream', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory()
-        const router = makeRouterDriver(history)(xs.of('/'), XSAdapter)
+        const router = makeRouterDriver(history, switchPath)(xs.of('/'), XSAdapter)
           .path('/')
         assert.notStrictEqual(router.path, null)
         assert.strictEqual(typeof router.path, 'function')
@@ -57,7 +58,7 @@ describe('Cyclic Router - XStream', () => {
         '/path/that/is/correct',
       ]
       const history = createServerHistory()
-      const router = makeRouterDriver(history)(xs.fromArray(routes), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.fromArray(routes), XSAdapter)
         .path('/path')
 
       router.history$.addListener({
@@ -78,7 +79,7 @@ describe('Cyclic Router - XStream', () => {
       ]
 
       const history = createServerHistory()
-      const router = makeRouterDriver(history)(xs.fromArray(routes), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.fromArray(routes), XSAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -100,7 +101,7 @@ describe('Cyclic Router - XStream', () => {
       ]
 
       const history = createServerHistory()
-      const router = makeRouterDriver(history)(xs.fromArray(routes), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.fromArray(routes), XSAdapter)
         .path('/some').path('/really').path('/really').path('/deeply')
         .path('/nested').path('/route').path('/that')
 
@@ -123,7 +124,7 @@ describe('Cyclic Router - XStream', () => {
       '`createHref` and `dispose`',
       () => {
         const history = createServerHistory()
-        const router = makeRouterDriver(history)(xs.merge(xs.never(), xs.of('/')), XSAdapter)
+        const router = makeRouterDriver(history, switchPath)(xs.merge(xs.never(), xs.of('/')), XSAdapter)
           .define({})
         assert.strictEqual(router instanceof xs, true)
         assert.strictEqual(typeof router.addListener, 'function')
@@ -139,7 +140,7 @@ describe('Cyclic Router - XStream', () => {
       }
 
       const history = createServerHistory('/some/route')
-      const router = makeRouterDriver(history)(xs.never(), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.never(), XSAdapter)
       const match$ = router.define(defintion)
 
       match$.addListener({
@@ -166,7 +167,7 @@ describe('Cyclic Router - XStream', () => {
       ]
 
       const history = createServerHistory('/wrong/path')
-      const router = makeRouterDriver(history)(xs.never(), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.never(), XSAdapter)
       const match$ = router.path('/some').path('/nested').define(defintion)
 
       match$.addListener({
@@ -194,7 +195,7 @@ describe('Cyclic Router - XStream', () => {
       }
 
       const history = createServerHistory('/wrong/path')
-      const router = makeRouterDriver(history)(xs.never(), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.never(), XSAdapter)
       const match$ = router.path('/some').path('/nested').define(definition)
 
       match$.addListener({
@@ -221,7 +222,7 @@ describe('Cyclic Router - XStream', () => {
       }
 
       const history = createServerHistory('/wrong/path')
-      const router = makeRouterDriver(history)(xs.never(), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.never(), XSAdapter)
       const match$ = router.path('/some').path('/nested').define(definition)
 
       match$.addListener({
@@ -251,7 +252,7 @@ describe('Cyclic Router - XStream', () => {
       }
 
       const history = createServerHistory('/wrong/path')
-      const router = makeRouterDriver(history)(xs.never(), XSAdapter)
+      const router = makeRouterDriver(history, switchPath)(xs.never(), XSAdapter)
       const match$ = router
           .path('/some').path('/nested').define(defintion)
 


### PR DESCRIPTION
In some cases I've wanted to inject my own matching algorithm (example:  I've created a custom reg-ex matcher for routes) and not use switch-path.  This PR allows users to inject when they `define` their routes.  I'm posting it for discussion and possibly for merge.