### PR TITLE
docs(README): Update history library breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import xs from 'xstream';
 import Cycle from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
 import {makeRouterDriver} from 'cyclic-router';
-import {createHistory} from 'history';
+import {createBrowserHistory} from 'history';
 import switchPath from 'switch-path';  // Required in v3, not required in v2 or below 
 
 function main(sources) {
@@ -61,7 +61,7 @@ function main(sources) {
 
 Cycle.run(main, {
   DOM: makeDOMDriver('#app'),
-  router: makeRouterDriver(createHistory(), switchPath)  // v3
+  router: makeRouterDriver(createBrowserHistory(), switchPath)  // v3
   // router: makeRouterDriver(createHistory()) // <= v2
 });
 ```


### PR DESCRIPTION
As it turns out, [history](https://github.com/reacttraining/history) has made a breaking change to their API (the way it exports) which may seem less intuitive to newcomers that may not understand why the example code does not work.