### PR TITLE
Export RouterSource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export {makeRouterDriver} from './makeRouterDriver';
+export {RouterSource} from './RouterSource';


### PR DESCRIPTION
It is common for Typescript users to declare their sources as an interface. Currently we have to type it `any`. This allows to use the actual `RouterSource` type