### PR TITLE
Stop importing @types/history

### DIFF
--- a/src/makeRouterDriver.ts
+++ b/src/makeRouterDriver.ts
@@ -1,7 +1,7 @@
 import {makeHistoryDriver} from '@cycle/history';
 import {RouteMatcher} from './interfaces';
 import {RouterSource} from './RouterSource';
-import {History} from '@types/history';
+import {History} from 'history';
 
 /**
  * Instantiates an new router driver function using the same arguments required


### PR DESCRIPTION
**Description:**

I get some compilation errors when using `cyclic-router` as a dependency. When cloning, installing and testing the project locally; I get the following output:

```
[rbelouin cyclic-router(master)]% npm install
npm WARN deprecated ghooks@1.3.2: Use npmjs.com/husky instead, see https://github.com/gtramontina/ghooks/issues/166

> ghooks@1.3.2 install /Users/rbelouin/src/cyclic-router/node_modules/ghooks
> node ./bin/module-install

cyclic-router@4.0.5 /Users/rbelouin/src/cyclic-router
├── @cycle/history@6.3.0
…
└── xstream@10.9.0
```

```
[rbelouin cyclic-router(master)]% npm test

> cyclic-router@4.0.5 pretest /Users/rbelouin/src/cyclic-router
> npm run lib


> cyclic-router@4.0.5 lib /Users/rbelouin/src/cyclic-router
> tsc

src/makeRouterDriver.ts(4,23): error TS6137: Cannot import type declaration files. Consider importing 'history' instead of '@types/history'.

npm ERR! Darwin 16.7.0
npm ERR! argv "/Users/rbelouin/.nvm/versions/node/v7.10.0/bin/node" "/Users/rbelouin/.nvm/versions/node/v7.10.0/bin/npm" "run" "lib"
npm ERR! node v7.10.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! cyclic-router@4.0.5 lib: `tsc`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the cyclic-router@4.0.5 lib script 'tsc'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the cyclic-router package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     tsc
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs cyclic-router
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls cyclic-router
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/rbelouin/.npm/_logs/2017-08-01T10_44_41_434Z-debug.log
npm ERR! Test failed.  See above for more details.
```

Even though everything works with tsc 2.3.3, the latest version (2.4.2) complains about `makeRouterDriver` importing `@types/history` instead of `history`. I followed the recommendation, and it works with both versions.