### PR TITLE
Add history to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "homepage": "https://github.com/cyclejs-community/cyclic-router#readme",
   "peerDependencies": {
-    "@cycle/history": "*"
+    "@cycle/history": "*",
+    "history": "*"
   },
   "dependencies": {
     "@cycle/run": "*"


### PR DESCRIPTION
When using pnpm, the folder structure is not flattened, this means to import functionality from `history` (in `routerify.ts`), we have to add it as peer dependency