### PR TITLE
Control page change with a key in state

### DIFF
--- a/src/RouterSource.ts
+++ b/src/RouterSource.ts
@@ -59,7 +59,16 @@ export class RouterSource {
         const _createHref = this._createHref;
         const createHref = util.makeCreateHref(namespace, _createHref);
 
-        return this._history$
+        return this._history$.fold(
+                ({ last }, actual) => ({
+                    last: actual,
+                    out: last?.state?.key && last?.state?.key === actual?.state?.key ? undefined : actual
+                }),
+                {
+                    last: undefined,
+                    out: undefined
+                }
+            ).filter(v => !!v.out).map(v => v.out)
             .map((location: Location) => {
                 const matcher = routeMatcher || this._routeMatcher;
                 const filteredPath = getFilteredPath(


### PR DESCRIPTION
Currently any new history change trigger a page component regeneration.

Sometimes may be helpful to update the url without trigger a page component recalc.

Proposed solution use a key attribute in the history object state.

If a key is present and the key of the new state is equal to the key of the old state the page component recalc is not triggered.